### PR TITLE
changed true/false to "true"/ "false" as boolean is still not supported

### DIFF
--- a/src/basics-of-bend.md
+++ b/src/basics-of-bend.md
@@ -49,9 +49,9 @@ Control flow in Bend allows you to make decisions in your code. The `if` stateme
 ```python
 def is_even(number):
   if number % 2 == 0:
-    return true
+    return "true"
   else:
-    return false
+    return "false"
 
 def main():
   return is_even(10)


### PR DESCRIPTION
The following example results in error.

```python
def is_even(number):
  if number % 2 == 0:
    return true
  else:
    return false

def main():
  return is_even(10)
```

╰─$ bend run filename.bend 
Errors:
In definition 'is_even':
  Unbound variable 'false'.
  Unbound variable 'true'.